### PR TITLE
Added new rules that make the image bigger on medium difficulty

### DIFF
--- a/javascript/puzzle.js
+++ b/javascript/puzzle.js
@@ -234,12 +234,12 @@ export let puzzle = ()=>{
             let tiles = container.querySelectorAll('li');
 
             if(newCol == 0){
-                container.style.height = '500px';
-                container.style.width = '500px';
+                container.style.height = '650px';
+                container.style.width = '650px';
 
                 tiles.forEach(tile =>{
-                    tile.style.height = "32%";
-                    tile.style.width = "32%";
+                    tile.style.height = "23%";
+                    tile.style.width = "23%";
                 })
             }
             else{

--- a/main.js
+++ b/main.js
@@ -9,11 +9,10 @@ const container = document.querySelector('#container');
 // let puzzleTwo = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,"empty"];
 let puzzlePos = ["left top","center top","right top","left center","center center","right center","left bottom","center bottom", "empty"];
 //Medium Difficulty Array
-// May need an array for every background image. This array is fine for EPCOT but looks off for other pictures.
-let puzzlePosMedium = ["left 8% top 0%","left 39% top 0%","right 34% top 0%","right 4% top 0%",
-"left 8% top 30%","left 34% top 32%","right 34% top 32%","right 4% top 30%",
-"left 8% top 180%","left 34% bottom 160%","right 34% bottom 160%","right 2% top 200%",
-"left 7% bottom 142%","left 36% bottom 142%", "right 36% bottom 142%","empty"];
+let puzzlePosMedium = ["left 7% top 0%","left 37% top 0%","right 33% top 0%","right 3% top 0%",
+"left 6% top 35%","left 37% top 35%","right 33% top 35%","right 2% top 35%",
+"left 6% bottom 160%","left 37% bottom 160%","right 33% bottom 160%","right 2% bottom 160%",
+"left 7% bottom 130%","left 37% bottom 130%", "right 33% bottom 130%","empty"];
 //For modal
 const gameModal = document.getElementById("gameModal-wrap");
 const modal = document.getElementById("modal-wrap");
@@ -118,7 +117,7 @@ function createHard(gridNum,puzzleNum){
     curDrag = puzzleCd.sortDrag(curPuzzleState);
     //Attribute draggable status to respective tiles
     puzzleCd.attributeDrag(curDrag);
-    //Create medium puzzle
+    //Create hard puzzle
     puzzleCd.hardDiff(gridNum, puzzleNum);
 }
 
@@ -302,7 +301,7 @@ const hard = document.getElementById("puzzle3");
 easy.addEventListener("click", function() {
     createPzl(3,puzzlePos);
 })
-medium.addEventListener("click", function() {
+medium.addEventListener("click", function(event) {
     //Found out the solution to the problem with generating puzzle images.
     //Need to make additional arrays for 4x4 and 5x5 puzzle grids.
     //However so far the array I made clones pieces of the background positions.

--- a/main.js
+++ b/main.js
@@ -9,10 +9,11 @@ const container = document.querySelector('#container');
 // let puzzleTwo = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,"empty"];
 let puzzlePos = ["left top","center top","right top","left center","center center","right center","left bottom","center bottom", "empty"];
 //Medium Difficulty Array
-let puzzlePosMedium = ["left -6% top 0%","left 36% top 0%","right 30% top 0%","right -12% top 0%",
-"left 0% top 35%","left 28% top 35%","right 28% top 35%","right -6% top 35%",
-"left 0% top 210%","left 28% bottom 160%","right 28% bottom 160%","right -6% top 210%",
-"left 0% bottom 122%","left 31% bottom 142%", "right 31% bottom 142%","empty"];
+// May need an array for every background image. This array is fine for EPCOT but looks off for other pictures.
+let puzzlePosMedium = ["left 8% top 0%","left 39% top 0%","right 34% top 0%","right 4% top 0%",
+"left 8% top 30%","left 34% top 32%","right 34% top 32%","right 4% top 30%",
+"left 8% top 180%","left 34% bottom 160%","right 34% bottom 160%","right 2% top 200%",
+"left 7% bottom 142%","left 36% bottom 142%", "right 36% bottom 142%","empty"];
 //For modal
 const gameModal = document.getElementById("gameModal-wrap");
 const modal = document.getElementById("modal-wrap");
@@ -79,6 +80,46 @@ function createPzl(gridNum,puzzleNum){
     curDrag = puzzleCd.sortDrag(curPuzzleState);
     //Attribute draggable status to respective tiles
     puzzleCd.attributeDrag(curDrag);
+}
+
+// Create medium difficulty puzzle based on the same rules as createPzl()
+function createMedium(gridNum,puzzleNum){
+    //Reset Puzzle
+    puzzleCd.resetPuzzle();
+    //variable that will keep track of puzzle state
+    curPuzzleState = [...puzzleNum];
+    //shuffle puzzle(shuffle the array)
+    puzzleCd.shufflePuzzle(curPuzzleState);
+    //Create puzzle
+    puzzleCd.createImgPuzzle(curPuzzleState, curImg);
+    //Resize container
+    puzzleCd.resizePuzzleContainer(gridNum);
+    //Sort draggable Tiles
+    curDrag = puzzleCd.sortDrag(curPuzzleState);
+    //Attribute draggable status to respective tiles
+    puzzleCd.attributeDrag(curDrag);
+    //Create medium puzzle
+    puzzleCd.mediumDiff(gridNum, puzzleNum);
+}
+
+// Create hard difficulty puzzle based on the same rules as createPzl()
+function createHard(gridNum,puzzleNum){
+    //Reset Puzzle
+    puzzleCd.resetPuzzle();
+    //variable that will keep track of puzzle state
+    curPuzzleState = [...puzzleNum];
+    //shuffle puzzle(shuffle the array)
+    puzzleCd.shufflePuzzle(curPuzzleState);
+    //Create puzzle
+    puzzleCd.createImgPuzzle(curPuzzleState, curImg);
+    //Resize container
+    puzzleCd.resizePuzzleContainer(gridNum);
+    //Sort draggable Tiles
+    curDrag = puzzleCd.sortDrag(curPuzzleState);
+    //Attribute draggable status to respective tiles
+    puzzleCd.attributeDrag(curDrag);
+    //Create medium puzzle
+    puzzleCd.hardDiff(gridNum, puzzleNum);
 }
 
 //disable the default behavior of the browser when dragging
@@ -255,10 +296,13 @@ prevImg.addEventListener("click", function () {
     createPzl(3,puzzlePos);
 });
 
+const easy = document.getElementById("puzzle1");
 const medium = document.getElementById("puzzle2");
 const hard = document.getElementById("puzzle3");
+easy.addEventListener("click", function() {
+    createPzl(3,puzzlePos);
+})
 medium.addEventListener("click", function() {
-    puzzleCd.mediumDiff(4, puzzlePosMedium);
     //Found out the solution to the problem with generating puzzle images.
     //Need to make additional arrays for 4x4 and 5x5 puzzle grids.
     //However so far the array I made clones pieces of the background positions.
@@ -266,8 +310,8 @@ medium.addEventListener("click", function() {
     // For what ever reason createPzl works just fine for generating a 4x4 puzzle grid. 
     // But hardDiff is necessary to generate a 5x5 grid.
     //NEEDS REVISE
-    createPzl(4,puzzlePosMedium);
+    createMedium(4,puzzlePosMedium);
 })
 hard.addEventListener("click", function() {
-    puzzleCd.hardDiff(4, puzzlePos);
+    createHard(6, puzzlePos);
 })


### PR DESCRIPTION
Created a new function in main.js that creates a puzzle based on medium difficulty rules. This is how I was able to make the list elements in medium difficulty the same width and height as the container. This made the image fit the puzzle pieces much better. I still think that there should be some refinements to the background positions on certain images. What i have now is fine for EPCOT but it looks off for other images. *UPDATE* I fixed the medium difficulty array and it should look fine on every background image. I just need to do hard difficulty and we're done.